### PR TITLE
feat: Dynamic scraper registration and new sales sources (greenMeUp, Palmenmann)

### DIFF
--- a/backend/src/controllers/sales/sources/greenMeUp.js
+++ b/backend/src/controllers/sales/sources/greenMeUp.js
@@ -16,12 +16,21 @@ module.exports = {
     return root
       .querySelectorAll(".ed-card-product")
       .map((item) => {
+        // The HTML uses .price--on-sale for the container
         const priceElem = item.querySelector(".price--on-sale");
         if (!priceElem) return null;
 
-        const linkElem = item.querySelector(
-          'a.full-unstyled-link[href^="/products/"]'
-        );
+        // TARGET SPECIFICITY: Use the H3 to get the actual visible title
+        const linkElem = item.querySelector("h3.card__heading a");
+
+        // IMAGE PROTOCOL FIX: Handle //greenmeup.de URLs
+        const imgElem = item.querySelector(".card__media img");
+        let imgSrc =
+          imgElem?.getAttribute("src") || imgElem?.getAttribute("data-src");
+
+        if (imgSrc && imgSrc.startsWith("//")) {
+          imgSrc = `https:${imgSrc}`;
+        }
 
         return {
           link: resolveLink(
@@ -29,9 +38,7 @@ module.exports = {
             "https://greenmeup.de"
           ),
           name: getText(linkElem),
-          img:
-            item.querySelector(".card__media img")?.getAttribute("src") ||
-            item.querySelector(".card__media img")?.getAttribute("data-src"),
+          img: imgSrc,
           oldPrice: parsePrice(
             priceElem.querySelector("s.price-item--regular")
           ),

--- a/backend/src/controllers/sales/sources/greenMeUp.js
+++ b/backend/src/controllers/sales/sources/greenMeUp.js
@@ -10,7 +10,7 @@ module.exports = {
   baseUrl: "https://greenmeup.de/collections/sale",
   pagePattern: "?page={{page}}",
   maxPages: 2,
-  options: { useChromium: false },
+  options: { useChromium: true },
 
   parseFn: (root) => {
     return root

--- a/backend/src/controllers/sales/sources/greenMeUp.js
+++ b/backend/src/controllers/sales/sources/greenMeUp.js
@@ -1,0 +1,43 @@
+const {
+  parsePrice,
+  resolveLink,
+  getText,
+} = require("../../../utils/scrapeUtils");
+
+module.exports = {
+  key: "greenMeUp",
+  seller: "Green Me Up",
+  baseUrl: "https://greenmeup.de/collections/sale",
+  pagePattern: "?page={{page}}",
+  maxPages: 2,
+  options: { useChromium: false },
+
+  parseFn: (root) => {
+    return root
+      .querySelectorAll(".ed-card-product")
+      .map((item) => {
+        const priceElem = item.querySelector(".price--on-sale");
+        if (!priceElem) return null;
+
+        const linkElem = item.querySelector(
+          'a.full-unstyled-link[href^="/products/"]'
+        );
+
+        return {
+          link: resolveLink(
+            linkElem?.getAttribute("href"),
+            "https://greenmeup.de"
+          ),
+          name: getText(linkElem),
+          img:
+            item.querySelector(".card__media img")?.getAttribute("src") ||
+            item.querySelector(".card__media img")?.getAttribute("data-src"),
+          oldPrice: parsePrice(
+            priceElem.querySelector("s.price-item--regular")
+          ),
+          newPrice: parsePrice(priceElem.querySelector(".price-item--sale")),
+        };
+      })
+      .filter(Boolean);
+  },
+};

--- a/backend/src/controllers/sales/sources/index.js
+++ b/backend/src/controllers/sales/sources/index.js
@@ -1,7 +1,23 @@
-const harmonyPlants = require("./harmonyPlants");
-const jungleLeaves = require("./jungleLeaves");
-const plnts = require("./plnts");
-const plantCircle = require("./plantCircle");
-const potflourri = require("./potflourri");
+const seenKeys = new Set();
 
-module.exports = [jungleLeaves, harmonyPlants, plnts, plantCircle, potflourri];
+module.exports = fs
+  .readdirSync(sourcesDir)
+  .filter((file) => file.endsWith(".js") && file !== "index.js")
+  .map((file) => {
+    const source = require(path.join(sourcesDir, file));
+
+    if (!source?.key) {
+      throw new Error(`Scraper in ${file} is missing 'key'`);
+    }
+
+    if (source.disabled) {
+      return null;
+    }
+
+    if (seenKeys.has(source.key)) {
+      throw new Error(`Duplicate scraper key "${source.key}" in ${file}`);
+    }
+
+    seenKeys.add(source.key);
+    return source;
+  });

--- a/backend/src/controllers/sales/sources/palmenmann.js
+++ b/backend/src/controllers/sales/sources/palmenmann.js
@@ -3,7 +3,7 @@ const { parsePrice, getText } = require("../../../utils/scrapeUtils");
 module.exports = {
   key: "palmenmann",
   seller: "Palmenmann",
-  baseUrl: "https://www.palmenmann.de/angebote",
+  baseUrl: "https://www.palmenmann.de/angebote/",
   pagePattern: "?p={{page}}",
   maxPages: 1,
   options: { useChromium: true },
@@ -20,14 +20,19 @@ module.exports = {
         );
         const oldPriceElem = priceBox.querySelector(".price--discount");
 
+        // We only want products that are actually on sale (have both prices)
         if (!newPriceElem || !oldPriceElem) return null;
 
         const linkElem = item.querySelector("a.product--title");
+        const imgElem = item.querySelector(".product--image img");
 
         return {
           link: linkElem?.getAttribute("href"),
           name: getText(linkElem),
-          img: item.querySelector(".product--image img")?.getAttribute("src"),
+          // Fallback to srcset if src is not present (common in their shop system)
+          img:
+            imgElem?.getAttribute("src") ||
+            imgElem?.getAttribute("srcset")?.split(" ")[0],
           oldPrice: parsePrice(oldPriceElem),
           newPrice: parsePrice(newPriceElem),
         };

--- a/backend/src/controllers/sales/sources/palmenmann.js
+++ b/backend/src/controllers/sales/sources/palmenmann.js
@@ -1,0 +1,37 @@
+const { parsePrice, getText } = require("../../../utils/scrapeUtils");
+
+module.exports = {
+  key: "palmenmann",
+  seller: "Palmenmann",
+  baseUrl: "https://www.palmenmann.de/angebote",
+  pagePattern: "?p={{page}}",
+  maxPages: 1,
+  options: { useChromium: false },
+
+  parseFn: (root) => {
+    return root
+      .querySelectorAll(".product--box")
+      .map((item) => {
+        const priceBox = item.querySelector(".product--price");
+        if (!priceBox) return null;
+
+        const newPriceElem = priceBox.querySelector(
+          ".price--default.is--discount"
+        );
+        const oldPriceElem = priceBox.querySelector(".price--discount");
+
+        if (!newPriceElem || !oldPriceElem) return null;
+
+        const linkElem = item.querySelector("a.product--title");
+
+        return {
+          link: linkElem?.getAttribute("href"),
+          name: getText(linkElem),
+          img: item.querySelector(".product--image img")?.getAttribute("src"),
+          oldPrice: parsePrice(oldPriceElem),
+          newPrice: parsePrice(newPriceElem),
+        };
+      })
+      .filter(Boolean);
+  },
+};

--- a/backend/src/controllers/sales/sources/palmenmann.js
+++ b/backend/src/controllers/sales/sources/palmenmann.js
@@ -6,7 +6,7 @@ module.exports = {
   baseUrl: "https://www.palmenmann.de/angebote",
   pagePattern: "?p={{page}}",
   maxPages: 1,
-  options: { useChromium: false },
+  options: { useChromium: true },
 
   parseFn: (root) => {
     return root

--- a/frontend/src/services/SalesServices.ts
+++ b/frontend/src/services/SalesServices.ts
@@ -33,48 +33,51 @@ export default class SalesService {
   ): Promise<Sale[]> | (() => void) {
     const accumulated: Sale[] = [];
 
+    // Shared handler to avoid duplication
+    const handleEvent = (event: { data: any }) => {
+      const chunk = SaleMapper.convertToSales(event.data);
+
+      chunk.forEach((s) => {
+        if (!accumulated.find((x) => x.id === s.id)) {
+          accumulated.push(s);
+        }
+      });
+
+      onUpdate(chunk);
+      cacheSalesData(accumulated);
+    };
+
     if (waitForDone) {
       return new Promise<Sale[]>((resolve, reject) => {
         const stop = ApiUtils.stream(
           BASE_ENDPOINT,
           (event) => {
             try {
-              const chunk = SaleMapper.convertToSales(event.data);
-              chunk.forEach((s) => {
-                if (!accumulated.find((x) => x.id === s.id))
-                  accumulated.push(s);
-              });
-
-              onUpdate(chunk);
-              cacheSalesData(accumulated);
-
-              if ((event.event || "").toLowerCase() === "done") {
-                stop();
-                resolve(accumulated);
-              }
+              handleEvent(event);
             } catch (err) {
               stop();
               reject(err);
             }
           },
-          (err) => reject(err)
+          (err) => {
+            stop();
+            reject(err);
+          },
+          () => {
+            stop();
+            resolve(accumulated);
+          }
         );
       });
-    } else {
-      return ApiUtils.stream(BASE_ENDPOINT, (event) => {
-        try {
-          const chunk = SaleMapper.convertToSales(event.data);
-          chunk.forEach((s) => {
-            if (!accumulated.find((x) => x.id === s.id)) accumulated.push(s);
-          });
-
-          onUpdate(chunk);
-          cacheSalesData(accumulated);
-        } catch (err) {
-          console.error("Error processing streamed sales data:", err);
-        }
-      });
     }
+
+    return ApiUtils.stream(BASE_ENDPOINT, (event) => {
+      try {
+        handleEvent(event);
+      } catch (err) {
+        console.error("Error processing streamed sales data:", err);
+      }
+    });
   }
 
   /** Get sales, using cache or streaming if no valid cache */

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -279,7 +279,8 @@ const ApiUtils = {
   stream<T = any>(
     endpoint: string,
     onMessage: StreamCallback<T>,
-    onError?: (err: any) => void
+    onError?: (err: any) => void,
+    onDone?: () => void
   ): () => void {
     const url = `${API_BASE_URL}${endpoint}`;
     const eventSource = new EventSource(url, { withCredentials: true });
@@ -294,13 +295,18 @@ const ApiUtils = {
       }
     };
 
+    eventSource.addEventListener("done", () => {
+      onDone?.();
+      eventSource.close();
+    });
+
     eventSource.onerror = (err) => {
       console.error("SSE stream error:", err);
       onError?.(err);
-      eventSource.close(); // optionally auto-close on error
+      eventSource.close();
     };
 
-    return () => eventSource.close(); // returns a stop function
+    return () => eventSource.close();
   },
 };
 


### PR DESCRIPTION
This Pull Request introduces a more scalable architecture for managing sales scrapers and expands the platform's reach by adding two new major plant retailers. It also includes critical fixes for image handling and strengthens the SSE (Server-Sent Events) streaming reliability on the frontend.

#### **Key Changes**

**1. Core Backend Improvements**

* **Dynamic Scraper Registration:** Refactored the scraper index to use `fs.readdirSync`. This eliminates the need to manually import and export every new scraper file; simply adding a `.js` file to the `sources` directory now registers it automatically.
* **Safety Checks:** Added validation during the dynamic loading process to prevent duplicate keys and ensure all scrapers export a required `key` property.
* **Chromium Support:** Enabled `useChromium: true` for specific sources that require a headless browser to bypass anti-bot measures or render JavaScript-heavy content.

**2. New Scrapers**

* **greenMeUp:** Added a new scraper for `greenmeup.de`.
* Features custom protocol handling for images starting with `//`.
* Targets specific CSS selectors for accurate sale price extraction.


* **Palmenmann:** Added a new scraper for `palmenmann.de`.
* Implements `srcset` parsing logic to ensure product images are captured even when standard `src` attributes are missing.
* Added logic to filter for products that are explicitly marked with a discount.



**3. Frontend & API Enhancements**

* **SSE Stream Robustness:** Refactored `SalesServices.ts` to use a shared event handler, reducing code duplication and ensuring the cache is updated consistently regardless of the stream state.
* **Stream Lifecycle Management:** Improved `apiUtils.ts` to properly handle the `done` event and ensure `EventSource` connections are closed cleanly, preventing memory leaks and hanging connections.

#### **Technical Details**

* **Additions:** 154 lines
* **Deletions:** 37 lines
* **Sources touched:** `greenMeUp.js`, `palmenmann.js`, `index.js` (backend), `SalesServices.ts`, `apiUtils.ts` (frontend).
